### PR TITLE
Sjekk utkast i tag og navn

### DIFF
--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -62,7 +62,9 @@
 '	/krav/SOSI-modellregister/ applikasjonsskjema/status
 '			Check if the ApplicationSchema-package got a tagged value named "SOSI_modellstatus" and checks if it is a valid value
 '   /krav/SOSI-modellregister/ applikasjonsskjema/versjonsnummer
-'            Check if the last part of the package name is a version number.  Ignore the text "Utkast" for this check
+'           Check if the last part of the package name is a version number.  Ignore the text "Utkast" for this check
+'   /krav/SOSI-modellregister/applikasjonsskjema/standard/pakkenavn/utkast
+'			Check if packages with SOSI_modellstatus tag "utkast" has "Utkast" in package name. Also do the reverse check.
 '  	/req/UML/constraint
 '			To check if a constraint lacks name or definition. 
 '  	/req/uml/packaging:
@@ -2128,7 +2130,42 @@ sub checkEndingOfPackageName(thePackage)
 end sub 
 '-------------------------------------------------------------END--------------------------------------------------------------------------------------------
 
+'------------------------------------------------------------START-------------------------------------------------------------------------------------------
+' Script Name: checkUtkast
+' Author: Åsmund Tjora	
+' Purpose: check that packages with "Utkast" as part of the package name also has "Utkast" as SOSI_modellstatus tag and that package with the "Utkast"
+' SOSI_modellstatus tag also has "Utkast" as part of the name. 
+' Date: 10.01.17 
+sub checkUtkast(thePackage)
+	dim utkastInName, utkastInTag
+	'check if "Utkast" is part of the name
+	if (len(thePackage.Name)=len(replace(UCase(thePackage.Name),"UTKAST",""))) then utkastInName=false else utkastInName=true
+	'check if "utkast" is part of the SOSI_modellstatus tag
+	dim taggedValuesCounter
+	dim SOSI_modellstatusTag
+	dim currentExistingTaggedValue
+	SOSI_modellstatusTag = "Missing Tag"
+	utkastInTag=false
+	for taggedValuesCounter = 0 to thePackage.Element.TaggedValues.Count - 1
+		set currentExistingTaggedValue = thePackage.Element.TaggedValues.GetAt(taggedValuesCounter)			
+		if currentExistingTaggedValue.Name = "SOSI_modellstatus" then
+			if currentExistingTaggedValue.Value = "utkast" then utkastInTag=true
+			SOSI_modellstatusTag=currentExistingTaggedValue.Value
+		end if
+	next
+	
+	if (utkastInName=true and utkastInTag=false) then
+		Session.Output("Error: Package [«"&thePackage.Element.Stereotype&"» "&thePackage.Element.Name& "] has Utkast as part of the name, but the tag [SOSI_modellstatus] has the value "&SOSI_modellstatusTag&" [/krav/SOSI-modellregister/applikasjonsskjema/standard/pakkenavn/utkast]")
+		globalErrorCounter = globalErrorCounter + 1 
+	end if 
 
+	if (utkastInName=false and utkastInTag=true) then
+		Session.Output("Error: Package [«"&thePackage.Element.Stereotype&"» "&thePackage.Element.Name& "] has [SOSI_modellstatus] tag with utkast value, but Utkast is not part of the package name [/krav/SOSI-modellregister/applikasjonsskjema/standard/pakkenavn/utkast]")
+		globalErrorCounter = globalErrorCounter + 1 
+	end if 
+end sub
+
+'-------------------------------------------------------------END--------------------------------------------------------------------------------------------
 
 
 
@@ -2156,6 +2193,7 @@ sub FindInvalidElementsInPackage(package)
 	end if
 
 	call checkEndingOfPackageName(package)
+	call checkUtkast(package)
 	
 	'Iso 19103 Requirement 16 - unique (NC?)Names on subpackages within the package.
 	if ClassAndPackageNames.IndexOf(UCase(package.Name),0) <> -1 then


### PR DESCRIPTION
Lagt til sjekk av SOSI_modellstatus tag og pakkenavn. Dersom tag er "utkast" må "Utkast" være en del av pakkenavnet og omvendt.