### PR TITLE
Issue #35

### DIFF
--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -359,8 +359,7 @@ end sub
 			end if 	 
  		Case else		 
  			'TODO: need some type of exception handling here
-			Session.Output( "Error: Function [CheckDefinition] started with invalid parameter.  DEBUG ME!") 
-			globalErrorCounter = globalErrorCounter + 1 
+			Session.Output( "Debug: Function [CheckDefinition] started with invalid parameter.") 
  	End Select 
  	 
 end sub 


### PR DESCRIPTION
Linje 362:
CheckDefinition blir slik skriptet ser ut, bare kalt for kjente typer,
og else-delen av select-strukturen blir dermed ikke aktivert.
Den bør stå som en debug-melding siden dette gir beskjed til
videreutviklere av skriptet.