### PR TITLE
packageDependency sub (stable, not finished)

### DIFF
--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -1,4 +1,4 @@
-﻿﻿option explicit 
+﻿option explicit 
  
  !INC Local Scripts.EAConstants-VBScript 
  
@@ -2520,18 +2520,27 @@ sub checkPackageDependency(thePackage)
 	'get package dependencies actually shown in package diagrams in model
 	call findPackageDependenciesShown(thePackage, packageDependenciesShown)
 	
+	'compare "real" dependencies made by referencing out-of-package elements with
+	'package dependencies declared in model and dependencies shown in diagrams
 	
 	dim packageID
 	dim investigatedPackage
+	dim investigatedElement
 	' do stuff to compare the packages containing actual (element) references, the declared dependencies and the shown dependencies
-	' for each package in packageExternalPackages
-	'  if not packageDependenciesShown.Contains(package) then
+	' for i 0 to referencedExternalPackages.Count-1
+	'  packageID=referencedExternalPackages[i]
+	'  if not packageDependenciesShown.Contains(packageID) then
+	'     elementID = referencedExternalElements[i]
+	'	  set investigatedPackage=Repository.GetElementByID(packageID)
+	'	  set investigatedElement=Repository.GetElementByID(elementID)
 	'     if not packageDependenceis.Contains(package) then
-	'       Session.Output("Error, use element from package not in model dependenceis")
+	'       Session.Output("Error, use of element " & investigatedElement.Name & " from package " & investigatedPackage.Name & " is not listed in model dependencies [/req/uml/integration]")
 	'     else
-	'       Session.Output("Error, use element from package not shown in package diagram")
+	'       Session.Output("Error, use of element " & investigatedElement.Name & " from package " & investigatedPackage.Name & " is not shown in any package diagram [/krav/17][/krav/21]")
 	'     end if
 	'  end if
+	
+	'check that dependencies are between ApplicationSchema packages.
 	for each packageID in packageDependencies
 		set investigatedPackage=Repository.GetElementByID(packageID)
 		if not UCase(investigatedPackage.Stereotype)="APPLICATIONSCHEMA" then

--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -2457,6 +2457,62 @@ sub checkInstantiable(theClass)
 end sub
 '-------------------------------------------------------------END--------------------------------------------------------------------------------------------
 
+'------------------------------------------------------------START-------------------------------------------------------------------------------------------
+' Script Name: checkPackageDependency
+' Author: Åsmund Tjora, Magnus Karge
+' Date: 170301
+' Purpose: Check that elements in external packages are accessible through package dependencies.  Check that dependency diagrams show these dependencies. 
+' Input parameter:  thePackage:  Package to be checked
+
+sub checkPackageDependency(thePackage)
+	dim externalElementList
+	set externalElementList=CreateObject("System.Collections.ArrayList")
+	dim packageDependencies
+	set packageDependencies=CreateObject("System.Collection.ArrayList")
+	dim packageDependenciesShown
+	set packageDependenciesShown=CreateObject("System.Collection.ArrayList")
+	
+	'get external elements (function or sub by Magnus)
+	'externalElementList=getElementIDsOfExternalElements(thePackage)
+	
+	'get external packages (function or sub by Magnus)
+	'call findPackagesToBeReferenced(externalElementList)
+	
+	'get package dependencies declared in ApplicationSchema model,
+	'get package dependencies actually shown in package diagrams in model
+	findPackageDependencies(thePackage, packageDependencies)
+	findPackageDependenciesShown(thePackage, packageDependenciesShown)
+
+end sub
+
+sub findPackageDependencies(thePackage, dependencyList)
+	dim connectorList as EA.Collection
+	dim packageConnector as EA.Connector
+	dim dependee as EA.Package
+	
+	connectorList=thePackage.Connectors
+	
+	for each packageConnector in connectorList
+		if packageConnector.Type="Usage" or packageConnector.Type="Package" then
+			if thePackage.PackageID = packageConnector.ClientID then
+				dependee = Repository.GetPackageByID(package.Connector.SupplierID)
+				dependencyList.Add(dependee.PackageID)
+				findPackageDependencies(dependee, dependencyList)
+			end if
+		end if
+	next
+end sub
+
+sub findPackageDependenciesShown(thePackage, dependencyList)
+	dim subPackages as EA.Collection
+	'find list of package diagrams
+	'in each package diagram find package corresponding to this application schema
+	'find shown links to other packages
+	'run findPackageDependencies on the linked to packages (i.e. do not care if dependee packages show their dependencies in diagrams)
+	
+	
+end sub
+'-------------------------------------------------------------END--------------------------------------------------------------------------------------------
 
 '------------------------------------------------------------START-------------------------------------------------------------------------------------------
 ' Sub Name: FindInvalidElementsInPackage

--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -2505,9 +2505,9 @@ sub checkPackageDependency(thePackage)
 	dim externalElementList
 	set externalElementList=CreateObject("System.Collections.ArrayList")
 	dim packageDependencies
-	set packageDependencies=CreateObject("System.Collection.ArrayList")
+	set packageDependencies=CreateObject("System.Collections.ArrayList")
 	dim packageDependenciesShown
-	set packageDependenciesShown=CreateObject("System.Collection.ArrayList")
+	set packageDependenciesShown=CreateObject("System.Collections.ArrayList")
 	
 	'get external elements (function or sub by Magnus)
 	'externalElementList=getElementIDsOfExternalElements(thePackage)
@@ -2517,24 +2517,30 @@ sub checkPackageDependency(thePackage)
 	
 	'get package dependencies declared in ApplicationSchema model,
 	'get package dependencies actually shown in package diagrams in model
-	findPackageDependencies(thePackage, packageDependencies)
-	findPackageDependenciesShown(thePackage, packageDependenciesShown)
+
+	call findPackageDependencies(thePackage.Element, packageDependencies)
+	call findPackageDependenciesShown(thePackage, packageDependenciesShown)
 
 end sub
 
-sub findPackageDependencies(thePackage, dependencyList)
+sub findPackageDependencies(thePackageElement, dependencyList)
 	dim connectorList as EA.Collection
 	dim packageConnector as EA.Connector
-	dim dependee as EA.Package
+	dim dependee as EA.Element
 	
-	connectorList=thePackage.Connectors
+	set connectorList=thePackageElement.Connectors
 	
 	for each packageConnector in connectorList
+		Session.Output("DEBUG: Investigating connector type " & packageConnector.Type & " from package " & thePackageElement.Name & ". ")
 		if packageConnector.Type="Usage" or packageConnector.Type="Package" then
-			if thePackage.PackageID = packageConnector.ClientID then
-				dependee = Repository.GetPackageByID(package.Connector.SupplierID)
-				dependencyList.Add(dependee.PackageID)
-				findPackageDependencies(dependee, dependencyList)
+			Session.Output("DEBUG:  Hooray, Current Package Element ID = " & thePackageElement.ElementID & ". Client ID = " &packageConnector.ClientID& ", Supplier ID = " &packageConnector.SupplierID& ".")
+			if thePackageElement.ElementID = packageConnector.ClientID then
+			
+				set dependee = Repository.GetElementByID(packageConnector.SupplierID)
+
+				Session.Output("DEBUG:  Added " &dependee.Name& " with ID " &dependee.ElementID& " to the dependency list")
+				dependencyList.Add(dependee.ElementID)
+				call findPackageDependencies(dependee, dependencyList)
 			end if
 		end if
 	next

--- a/SOSIModelValidation.vbs
+++ b/SOSIModelValidation.vbs
@@ -2497,7 +2497,7 @@ end sub
 '------------------------------------------------------------START-------------------------------------------------------------------------------------------
 ' Script Name: checkPackageDependency
 ' Author: Åsmund Tjora, Magnus Karge
-' Date: 170301
+' Date: 170329
 ' Purpose: Check that elements in external packages are accessible through package dependencies.  Check that dependency diagrams show these dependencies. 
 ' Input parameter:  thePackage:  Package to be checked
 
@@ -2516,11 +2516,29 @@ sub checkPackageDependency(thePackage)
 	'call findPackagesToBeReferenced(externalElementList)
 	
 	'get package dependencies declared in ApplicationSchema model,
-	'get package dependencies actually shown in package diagrams in model
-
 	call findPackageDependencies(thePackage.Element, packageDependencies)
+	'get package dependencies actually shown in package diagrams in model
 	call findPackageDependenciesShown(thePackage, packageDependenciesShown)
 	
+	
+	dim packageID
+	dim investigatedPackage
+	' do stuff to compare the packages containing actual (element) references, the declared dependencies and the shown dependencies
+	' for each package in packageExternalPackages
+	'  if not packageDependenciesShown.Contains(package) then
+	'     if not packageDependenceis.Contains(package) then
+	'       Session.Output("Error, use element from package not in model dependenceis")
+	'     else
+	'       Session.Output("Error, use element from package not shown in package diagram")
+	'     end if
+	'  end if
+	for each packageID in packageDependencies
+		set investigatedPackage=Repository.GetElementByID(packageID)
+		if not UCase(investigatedPackage.Stereotype)="APPLICATIONSCHEMA" then
+			Session.Output("Warning: Dependency to package [«" & investigatedPackage.Stereotype & "» " & investigatedPackage.Name & "] found.  Dependencies shall only be to ApplicationSchema packages or Standard schemas. [req/uml/integration]")
+			globalWarningCounter = globalWarningCounter + 1
+		end if
+	next
 end sub
 
 sub findPackageDependencies(thePackageElement, dependencyList)
@@ -2591,7 +2609,6 @@ sub findPackageDependenciesShown(thePackage, dependencyList)
 	next	
 end sub
 '-------------------------------------------------------------END--------------------------------------------------------------------------------------------
-
 
 '------------------------------------------------------------START-------------------------------------------------------------------------------------------
 ' Function Name: getElementIDsOfExternalReferencedElements
@@ -2704,6 +2721,7 @@ sub FindInvalidElementsInPackage(package)
 
 	call checkEndingOfPackageName(package)
 	call checkUtkast(package)
+	call checkPackageDependency(package)
 	
 	'Iso 19103 Requirement 16 - unique (NC?)Names on subpackages within the package.
 	if ClassAndPackageNames.IndexOf(UCase(package.Name),0) <> -1 then


### PR DESCRIPTION
packageDependency sub now detects model dependencies and diagram (shown) dependencies.
  Check that model dependencies are to ApplicationSchema packages: implemented (with Warning, not Error, as dependency to standard (non-application-) schemas is allowed)
* Comparison of shown dependencies and real (element usage) dependencies pending on list of packages for real dependencies.

First version.  
Not implemented:
Check of diagram nested in the current package.
Check that dependency does not have a non-applicationschema dependant (may be important for nested packages).
Probable issue if dependency diagram does not contain starting application schema.